### PR TITLE
Remove redundant headers override from client init

### DIFF
--- a/Thirdweb/Thirdweb.Client/ThirdwebClient.cs
+++ b/Thirdweb/Thirdweb.Client/ThirdwebClient.cs
@@ -21,14 +21,7 @@ public class ThirdwebClient
     internal string BundleId { get; }
     internal ITimeoutOptions FetchTimeoutOptions { get; }
 
-    private ThirdwebClient(
-        string clientId = null,
-        string secretKey = null,
-        string bundleId = null,
-        ITimeoutOptions fetchTimeoutOptions = null,
-        IThirdwebHttpClient httpClient = null,
-        Dictionary<string, string> headers = null
-    )
+    private ThirdwebClient(string clientId = null, string secretKey = null, string bundleId = null, ITimeoutOptions fetchTimeoutOptions = null, IThirdwebHttpClient httpClient = null)
     {
         if (string.IsNullOrEmpty(clientId) && string.IsNullOrEmpty(secretKey))
         {
@@ -49,21 +42,30 @@ public class ThirdwebClient
 
         this.FetchTimeoutOptions = fetchTimeoutOptions ?? new TimeoutOptions();
 
-        this.HttpClient = httpClient ?? new ThirdwebHttpClient();
-
-        this.HttpClient.SetHeaders(
-            headers
-                ?? new Dictionary<string, string>
-                {
-                    { "x-sdk-name", "Thirdweb.NET" },
-                    { "x-sdk-os", System.Runtime.InteropServices.RuntimeInformation.OSDescription },
-                    { "x-sdk-platform", "dotnet" },
-                    { "x-sdk-version", Constants.VERSION },
-                    { "x-client-id", this.ClientId },
-                    { "x-secret-key", this.SecretKey },
-                    { "x-bundle-id", this.BundleId }
-                }
-        );
+        if (httpClient != null)
+        {
+            this.HttpClient = httpClient;
+        }
+        else
+        {
+            var defaultHeaders = new Dictionary<string, string>
+            {
+                { "x-sdk-name", "Thirdweb.NET" },
+                { "x-sdk-os", System.Runtime.InteropServices.RuntimeInformation.OSDescription },
+                { "x-sdk-platform", "dotnet" },
+                { "x-sdk-version", Constants.VERSION },
+                { "x-client-id", this.ClientId },
+            };
+            if (!string.IsNullOrEmpty(this.SecretKey))
+            {
+                defaultHeaders.Add("x-secret-key", this.SecretKey);
+            }
+            if (!string.IsNullOrEmpty(this.BundleId))
+            {
+                defaultHeaders.Add("x-bundle-id", this.BundleId);
+            }
+            this.HttpClient = new ThirdwebHttpClient(defaultHeaders);
+        }
     }
 
     /// <summary>
@@ -74,17 +76,9 @@ public class ThirdwebClient
     /// <param name="bundleId">The bundle ID (optional).</param>
     /// <param name="fetchTimeoutOptions">The fetch timeout options (optional).</param>
     /// <param name="httpClient">The HTTP client (optional).</param>
-    /// <param name="headers">The headers to set on the HTTP client (optional).</param>
     /// <returns>A new instance of <see cref="ThirdwebClient"/>.</returns>
-    public static ThirdwebClient Create(
-        string clientId = null,
-        string secretKey = null,
-        string bundleId = null,
-        ITimeoutOptions fetchTimeoutOptions = null,
-        IThirdwebHttpClient httpClient = null,
-        Dictionary<string, string> headers = null
-    )
+    public static ThirdwebClient Create(string clientId = null, string secretKey = null, string bundleId = null, ITimeoutOptions fetchTimeoutOptions = null, IThirdwebHttpClient httpClient = null)
     {
-        return new ThirdwebClient(clientId, secretKey, bundleId, fetchTimeoutOptions, httpClient, headers);
+        return new ThirdwebClient(clientId, secretKey, bundleId, fetchTimeoutOptions, httpClient);
     }
 }

--- a/Thirdweb/Thirdweb.Http/ThirdwebHttpClient.cs
+++ b/Thirdweb/Thirdweb.Http/ThirdwebHttpClient.cs
@@ -16,10 +16,10 @@ public class ThirdwebHttpClient : IThirdwebHttpClient
     /// <summary>
     /// Initializes a new instance of the <see cref="ThirdwebHttpClient"/> class.
     /// </summary>
-    public ThirdwebHttpClient()
+    public ThirdwebHttpClient(Dictionary<string, string> defaultHeaders = null)
     {
         this._httpClient = new HttpClient();
-        this.Headers = new();
+        this.Headers = defaultHeaders ?? new Dictionary<string, string>();
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the constructors of the `ThirdwebHttpClient` and `ThirdwebClient` classes to improve header management and simplify the creation process by removing the direct header parameter.

### Detailed summary
- Updated `ThirdwebHttpClient` constructor to accept `Dictionary<string, string> defaultHeaders`.
- Removed the `headers` parameter from the `ThirdwebClient` constructor.
- Enhanced `ThirdwebClient` to set default headers conditionally based on provided values.
- Simplified the `Create` method in `ThirdwebClient` by removing the `headers` parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->