### PR TITLE
Add preferredProvider option for thirdweb pay

### DIFF
--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -411,6 +411,7 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 // Console.WriteLine($"Supported currencies: {JsonConvert.SerializeObject(supportedCurrencies, Formatting.Indented)}");
 
 // // Get a Buy with Fiat quote
+// var fiatQuoteParamsWithProvider = new BuyWithFiatQuoteParams(fromCurrencySymbol: "USD", toAddress: walletAddress, toChainId: "137", toTokenAddress: Constants.NATIVE_TOKEN_ADDRESS, toAmount: "20", preferredProvider: "STRIPE");
 // var fiatQuoteParams = new BuyWithFiatQuoteParams(fromCurrencySymbol: "USD", toAddress: walletAddress, toChainId: "137", toTokenAddress: Constants.NATIVE_TOKEN_ADDRESS, toAmount: "20");
 // var fiatOnrampQuote = await ThirdwebPay.GetBuyWithFiatQuote(client, fiatQuoteParams);
 // Console.WriteLine($"Fiat onramp quote: {JsonConvert.SerializeObject(fiatOnrampQuote, Formatting.Indented)}");

--- a/Thirdweb/Thirdweb.Pay/ThirdwebPay.GetBuyWithFiatQuote.cs
+++ b/Thirdweb/Thirdweb.Pay/ThirdwebPay.GetBuyWithFiatQuote.cs
@@ -26,6 +26,7 @@ public partial class ThirdwebPay
             { "toTokenAddress", buyWithFiatParams.ToTokenAddress },
             { "toAmount", buyWithFiatParams.ToAmount },
             { "toAmountWei", buyWithFiatParams.ToAmountWei },
+            { "preferredProvider", buyWithFiatParams.PreferredProvider },
             { "maxSlippageBPS", buyWithFiatParams.MaxSlippageBPS?.ToString() }
         };
 

--- a/Thirdweb/Thirdweb.Pay/Types.GetBuyWithFiatQuote.cs
+++ b/Thirdweb/Thirdweb.Pay/Types.GetBuyWithFiatQuote.cs
@@ -18,7 +18,8 @@ public class BuyWithFiatQuoteParams(
     string toAmount = null,
     string toAmountWei = null,
     double? maxSlippageBPS = null,
-    bool isTestMode = false
+    bool isTestMode = false,
+    string preferredProvider = null
     )
 {
     /// <summary>
@@ -38,7 +39,12 @@ public class BuyWithFiatQuoteParams(
     /// </summary>
     [JsonProperty("fromAmountUnits")]
     public string FromAmountUnits { get; set; } = fromAmountUnits;
-
+    
+    /// <summary>
+    /// The provider to use on the application for fiat
+    /// </summary>
+    [JsonProperty("preferredProvider")]
+    public string PreferredProvider { get; set; } = preferredProvider;
     /// <summary>
     /// The address to receive the purchased tokens.
     /// </summary>

--- a/Thirdweb/Thirdweb.Pay/Types.GetBuyWithFiatQuote.cs
+++ b/Thirdweb/Thirdweb.Pay/Types.GetBuyWithFiatQuote.cs
@@ -41,7 +41,7 @@ public class BuyWithFiatQuoteParams(
     public string FromAmountUnits { get; set; } = fromAmountUnits;
     
     /// <summary>
-    /// The provider to use on the application for fiat
+    /// The provider to use on the application for thirdweb pay
     /// </summary>
     [JsonProperty("preferredProvider")]
     public string PreferredProvider { get; set; } = preferredProvider;


### PR DESCRIPTION
Adding the `preferredProvider` option for thirdweb pay.

Reference: https://portal.thirdweb.com/references/typescript/v5/GetBuyWithFiatQuoteParams